### PR TITLE
accept-language logic and zhwiki config.

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import chdb
+import chstrings
 import config
 import handlers
 import utils
@@ -91,8 +92,16 @@ def page_not_found(e):
         cfg = flask.g._cfg
     else:
         cfg = config.get_localized_config('en')
+    if hasattr(flask.g, '_strings'):
+        lang_tag = flask.g._lang_tag
+        strings = flask.g._strings
+    else:
+        lang_tag = 'en'
+        strings = chstrings.get_localized_strings(cfg, 'en')
     return flask.render_template(
-        '404.html', config = cfg), 404
+        '404.html', config = cfg,
+        lang_tag = lang_tag,
+        lang_dir = cfg.lang_dir, strings = strings), 404
 
 @app.errorhandler(500)
 def internal_server_error(e):

--- a/app_test.py
+++ b/app_test.py
@@ -87,6 +87,23 @@ class CitationHuntTest(unittest.TestCase):
         self.assertEquals(response.status_code, 302)
         self.assertTrue(response.location.endswith('/en'))
 
+    def test_zh_redirects(self):
+        # Just use the real config for these, make sure we properly
+        # match Chinese headers with the lang code
+        response = self.app.get('/', headers = {'Accept-Language': 'zh-TW'})
+        self.assertEquals(response.status_code, 302)
+        self.assertTrue(response.location.endswith('/zh_hant'))
+
+        response = self.app.get('/', headers = {'Accept-Language': 'zh-CN'})
+        self.assertEquals(response.status_code, 302)
+        self.assertTrue(response.location.endswith('/zh_hans'))
+
+    def test_zh_html_lang(self):
+        # Again using the new config, request zh_hans and make sure the
+        # language attribute is set correctly in the response
+        response = self.app.get('/zh_hans?id=' + self.sid)
+        self.assertIn('lang="zh-Hans"', response.data)
+
     def test_no_id_no_category(self):
         response = self.app.get('/en')
         args = self.get_url_args(response.location)

--- a/chstrings/__init__.py
+++ b/chstrings/__init__.py
@@ -80,9 +80,13 @@ def _partition_js_strings(strings):
         if k.startswith('js-'):
             strings['js'][k[3:]] = strings.pop(k)
 
-def get_localized_strings(config, lang_code):
+def get_localized_strings(config, lang_tag):
     strings_dir = os.path.dirname(__file__)
-    strings = json.load(file(os.path.join(strings_dir, lang_code + '.json')))
+    json_path = os.path.join(strings_dir, lang_tag.lower() + '.json')
+    try:
+        strings = json.load(file(json_path))
+    except:
+        return {}
     strings = _preprocess_variables(config, strings)
     _partition_js_strings(strings)
     return strings

--- a/config.py
+++ b/config.py
@@ -592,6 +592,55 @@ _LANG_CODE_TO_CONFIG = dict(
 
         snippet_max_size = 1000,
     ),
+
+    zh_hant = dict(
+        lang_name = '繁體中文',
+        lang_dir = 'ltr',
+        accept_language = [
+            'zh-TW',
+            'zh-HK',
+            'zh-MO',
+            'zh-Hant',
+        ],
+        database = 'zhwiki_p',
+        wikipedia_domain = 'zh.wikipedia.org',
+        beginners_link = 'https://zh.wikipedia.org/wiki/Wikipedia:列明来源',
+        beginners_link_title = 'Wikipedia:列明來源',
+        lead_section_policy_link = 'https://zh.wikipedia.org/wiki/Wikipedia:LEADCITE',
+        lead_section_policy_link_title = '序言章節的引用',
+        citation_needed_category = '有未列明来源语句的条目',
+        citation_needed_templates = [
+            'Unreferenced',
+            'Fact',
+        ],
+        citation_needed_template_name = '来源请求',
+        hidden_category = '隐藏分类',
+        snippet_max_size = 1000,
+    ),
+
+    zh_hans = dict(
+        lang_name = '简体中文',
+        lang_dir = 'ltr',
+        accept_language = [
+            'zh-CN',
+            'zh-SG',
+            'zh-Hans',
+        ],
+        database = 'zhwiki_p',
+        wikipedia_domain = 'zh.wikipedia.org',
+        beginners_link = 'https://zh.wikipedia.org/wiki/Wikipedia:列明来源',
+        beginners_link_title = 'Wikipedia:列明来源',
+        lead_section_policy_link = 'https://zh.wikipedia.org/wiki/Wikipedia:LEADCITE',
+        lead_section_policy_link_title = '序言章节的引用',
+        citation_needed_category = '有未列明来源语句的条目',
+        citation_needed_templates = [
+            'Unreferenced',
+            'Fact',
+        ],
+        citation_needed_template_name = '來源請求',
+        hidden_category = '隐藏分类',
+        snippet_max_size = 1000,
+    )
 )
 
 # In py3: types.SimpleNamespace

--- a/handlers/citationhunt.py
+++ b/handlers/citationhunt.py
@@ -138,6 +138,7 @@ def citation_hunt(lang_code):
     id = flask.request.args.get('id')
     cat = flask.request.args.get('cat')
     cfg = flask.g._cfg
+    strings = flask.g._strings
 
     lang_dir = cfg.lang_dir
     if flask.current_app.debug:
@@ -183,8 +184,10 @@ def citation_hunt(lang_code):
             ref_marker = REF_MARKER,
             ref_html = SUPERSCRIPT_MARKUP,
             config = cfg,
+            lang_tag = flask.g._lang_tag,
             lang_dir = lang_dir,
-            js_strings = cfg.strings['js'])
+            strings = strings,
+            js_strings = strings['js'])
 
     id = select_random_id(lang_code, cat)
     return flask.redirect(

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -1,5 +1,6 @@
 import chdb
 import config
+import chstrings
 
 import flask
 
@@ -29,18 +30,80 @@ def get_stats_db():
         db = flask.g._stats_db = chdb.init_stats_db()
     return db
 
+def redirect_to_lang_code(lang_code):
+    response = flask.redirect(
+    flask.url_for('citation_hunt', lang_code = lang_code,
+        **flask.request.args))
+    if flask.request.path != '/':
+        response.headers['Location'] += flask.request.path
+    return response
+
+def find_default_lang_code_for_request(accept_language_hdr):
+    lang_tags_in_header = [
+        l.split(';', 1)[0]
+        for l in accept_language_hdr.split(',')
+    ] # en-GB, en;q=0.5, es-AR;q=0.3 -> [en-GB, en, es-AR]
+    for lang_tag in lang_tags_in_header:
+        for lcode, ltags in config.LANG_CODES_TO_ACCEPT_LANGUAGE.items():
+            if lang_tag in ltags or lcode == lang_tag:
+                return lcode
+    return 'en'
+
+# A lang_code in the config identifies a set of config keys, but
+# it is orthogonal to the set of strings we'll use in the UI. Try
+# to determine the strings here.
+def load_strings_for_request(lang_code, cfg, accept_language_hdr):
+    header_locales = accept_language_hdr.split(',')
+    for l in header_locales:
+        lang_tag = l.split(';', 1)[0]  # drop weight, if any
+        lang = l.split('-', 1)[0] # en-GB -> en
+
+        lang_tag_matches_config = (
+            lang == lang_code or
+            lang_tag in cfg.accept_language or
+            lang in cfg.accept_language
+        )
+        if not lang_tag_matches_config:
+            continue
+
+        # Do we have strings for the full tag?
+        strings = chstrings.get_localized_strings(cfg, lang_tag)
+        if strings:
+            return lang_tag, strings
+        # Maybe just the lang?
+        strings = chstrings.get_localized_strings(cfg, lang)
+        if strings:
+            return lang, strings
+
+    fallback = lang_code
+    if cfg.accept_language:
+        fallback = cfg.accept_language[-1]
+    return fallback, chstrings.get_localized_strings(cfg, fallback)
+
 def validate_lang_code(handler):
     @functools.wraps(handler)
     def wrapper(lang_code = '', *args, **kwds):
+        accept_language_hdr = flask.request.headers.get('Accept-Language', '')
+        if not lang_code:
+            return redirect_to_lang_code(
+                find_default_lang_code_for_request(accept_language_hdr))
+
         flask.g._lang_code = lang_code
         if lang_code not in config.LANG_CODES_TO_LANG_NAMES:
-            response = flask.redirect(
-                flask.url_for('citation_hunt', lang_code = 'en',
-                    **flask.request.args))
-            if flask.request.path != '/':
-                response.headers['Location'] += flask.request.path
-            return response
+            return redirect_to_lang_code('en')
+
         flask.g._cfg = config.get_localized_config(lang_code)
+        if flask.current_app.debug and 'locale' in flask.request.args:
+            flask.g._strings = chstrings.get_localized_strings(
+                cfg, flask.request.args['locale'])
+        else:
+            flask.g._lang_tag, flask.g._strings = load_strings_for_request(
+                lang_code, flask.g._cfg, accept_language_hdr)
+        if not flask.g._strings:
+            # Shouldn't really happen, this means we have a misconfigured
+            # language that has a config entry but no locales in the translation
+            # files.
+            return redirect_to_lang_code('en')
         return handler(lang_code, *args, **kwds)
     return wrapper
 

--- a/handlers/common_test.py
+++ b/handlers/common_test.py
@@ -1,0 +1,82 @@
+import os
+import sys
+_upper_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..'))
+if _upper_dir not in sys.path:
+    sys.path.append(_upper_dir)
+
+import common
+import config
+
+import mock
+import unittest
+
+class HandlersCommonTest(unittest.TestCase):
+    def _test_load_strings_for_request(self, allowed_lang_tags,
+            lang_code, accept_language_hdr, accept_language = []):
+        tested_lang_tags = []
+        cfg = config.Config(accept_language = accept_language)
+        def fake_get_localized_strings(_, lang_tag):
+            tested_lang_tags.append(lang_tag)
+            if lang_tag.lower() in allowed_lang_tags:
+                return {'ok': True}
+            return {}
+        with mock.patch(
+            'common.chstrings.get_localized_strings',
+            side_effect = fake_get_localized_strings):
+            lang_tag, strings = common.load_strings_for_request(
+                lang_code, cfg, accept_language_hdr)
+        # Must have eventually loaded a valid set of strings
+        self.assertEquals(strings, {'ok': True})
+        return lang_tag, tested_lang_tags
+
+    def test_ui_lang_simple_en(self):
+        r, tested_lang_tags = self._test_load_strings_for_request(
+            ['en', 'en-gb', 'fr', 'fi'], 'en', 'en-US,en;q=0.5')
+        self.assertEquals(r, 'en')
+        self.assertEquals(tested_lang_tags, ['en-US', 'en'])
+
+    def test_ui_lang_simple_fr(self):
+        # Just another smoke test, with the difference that fr, unlike en,
+        # has no variants.
+        r, tested_lang_tags = self._test_load_strings_for_request(
+            ['en', 'en-gb', 'fr', 'fi'], 'fr', 'fr,en;q=0.5')
+        self.assertEquals(r, 'fr')
+        self.assertEquals(tested_lang_tags, ['fr'])
+
+    def test_ui_lang_en_with_hdr_en_gb(self):
+        # Header should override URL, but only for selecting a locale variant.
+        r, tested_lang_tags = self._test_load_strings_for_request(
+            ['en', 'en-gb', 'fr', 'fi'], 'en', 'en-GB,en-US;q=0.5,en;q=0.5')
+        self.assertEquals(r, 'en-GB')
+        self.assertEquals(tested_lang_tags, ['en-GB'])
+
+    def test_ui_lang_fr_with_hdr_en_gb(self):
+        # We should still respect the URL if it chooses a locale that we know,
+        # even if it disagrees with the header, when the header doesn't provide
+        # a variant of the URL's locale.
+        r, tested_lang_tags = self._test_load_strings_for_request(
+            ['en', 'en-gb', 'fr', 'fi'], 'fr', 'en-GB,en-US;q=0.5,en;q=0.5')
+        self.assertEquals(r, 'fr')
+        self.assertEquals(tested_lang_tags, ['fr'])
+
+    # zh_{hans,hant} differ from en/en-gb because the lang tag doesn't match
+    # the lang code ever (- vs. _) so we always use the fallback.
+    def test_ui_lang_zh_hant_with_hdr_tw_fallback_zh_hant(self):
+        r, tested_lang_tags = self._test_load_strings_for_request(
+            ['en', 'fr', 'fi', 'zh-hant', 'zh-hans'], 'zh_hant',
+            'zh-TW,en;q=0.5', accept_language = ['zh-TW', 'zh-Hant'])
+        self.assertEquals(r, 'zh-Hant')
+        self.assertEquals(tested_lang_tags, ['zh-TW', 'zh', 'zh-Hant'])
+
+    def test_ui_lang_zh_hant_with_hdr_en_fallback_zh_hant(self):
+        # Here the user doesn't accept any of the language tags expected by the
+        # config, we should still use the fallback.
+        r, tested_lang_tags = self._test_load_strings_for_request(
+            ['en', 'fr', 'fi', 'zh-hant', 'zh-hans'], 'zh_hant',
+            'en-US,en;q=0.5', accept_language = ['zh-TW', 'zh-Hant'])
+        self.assertEquals(r, 'zh-Hant')
+        self.assertEquals(tested_lang_tags, ['zh-Hant'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
 
-<html lang={{ config.lang_code }} dir={{ lang_dir }}>
+<html lang={{ lang_tag }} dir={{ lang_dir }}>
   <head>
     {% block head_extras %}{% endblock %}
-    <title>{{ config.strings.tooltitle }}</title>
+    <title>{{ strings.tooltitle }}</title>
     <meta name="robots" content="nofollow, noodp, noindex">
-    <meta name="description" content="{{ config.strings.tooltitle }} - {{ config.strings.introduction }}">
+    <meta name="description" content="{{ strings.tooltitle }} - {{ strings.introduction }}">
     <!-- Since the 404 handler can be invoked for arbitrarily broken URLs, let's
         not bother requesting style.css using its relative path, but rather just
         inline the relevant CSS. -->
@@ -29,8 +29,8 @@
       </style>
   </head>
   <body>
-    <h1>{{ config.strings.page_not_found }}</h1>
-    <p>{{ config.strings.page_not_found_text }}</p>
+    <h1>{{ strings.page_not_found }}</h1>
+    <p>{{ strings.page_not_found_text }}</p>
     {% block bottom_extras %}{% endblock %}
   </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 
-<html lang="{{ config.lang_code }}" dir="{{ lang_dir }}">
+<html lang="{{ lang_tag }}" dir="{{ lang_dir }}">
   <head>
     {% block head_extras %}{% endblock %}
-    <title>{{ config.strings.tooltitle }}</title>
+    <title>{{ strings.tooltitle }}</title>
     <link rel="stylesheet" href="static/style.css">
     <link rel="stylesheet" href="static/awesomplete.css">
 
@@ -24,19 +24,19 @@
     <script src="static/js/fixed.js" defer></script>
     <script src="static/js/shortcuts.js" defer></script>
     <meta name="robots" content="nofollow, noodp">
-    <meta name="description" content="{{ config.strings.tooltitle }} - {{ config.strings.introduction }}">
+    <meta name="description" content="{{ strings.tooltitle }} - {{ strings.introduction }}">
   </head>
   <body>
-    <h1>{{ config.strings.tooltitle }}</h1>
-    {% if config.strings.instructions_goal %}
+    <h1>{{ strings.tooltitle }}</h1>
+    {% if strings.instructions_goal %}
     <div id=instructions class="info">
-        <p>{{ config.strings.instructions_goal }}</p>
-        <p>{{ config.strings.instructions_details }}</p>
+        <p>{{ strings.instructions_goal }}</p>
+        <p>{{ strings.instructions_details }}</p>
     </div>
     {% else %}
-    <p id="intro">{{ config.strings.introduction }}</p>
+    <p id="intro">{{ strings.introduction }}</p>
     {% endif %}
-    <p id="preamble"><span id="page-title-text">{{ config.strings.in_page % (article_url, article_title) }}</span></p>
+    <p id="preamble"><span id="page-title-text">{{ strings.in_page % (article_url, article_title) }}</span></p>
     {# use a list for snippet_html to make sure we can access it outside the loop; see https://stackoverflow.com/questions/4870346 #}
     {% set cn_html = cn_html % config.citation_needed_template_name | replace(' ', '&thinsp;') | safe %}
     {% set snippet_html = [snippet | replace(cn_marker, cn_html)] %}
@@ -48,25 +48,25 @@
             <div id="quotation">"</div>
             {{ snippet_html[-1] }}
         </blockquote>
-        {% if not section and config.strings.lead_section_hint %}<div id="lead-hint">{{ config.strings.lead_section_hint }}</div>{% endif %}
+        {% if not section and strings.lead_section_hint %}<div id="lead-hint">{{ strings.lead_section_hint }}</div>{% endif %}
     </div>
     <div id="after-snippet">
       <div>
         <a href="{{ config.lang_code }}/redirect?id={{ snippet_id }}&to={{ article_url_path }}{% if section %}#{{ section }}{% endif %}"
-          target="_blank"><button class="button" id="button-wikilink">{{ config.strings.button_wikilink }}</button></a>
-        <button form="form-next" type="submit" id="button-next" class="button">{{ config.strings.button_next }}</button>
+          target="_blank"><button class="button" id="button-wikilink">{{ strings.button_wikilink }}</button></a>
+        <button form="form-next" type="submit" id="button-next" class="button">{{ strings.button_next }}</button>
       </div>
       <div id="category-filter-wrapper">
         <form method="GET" action="" id="form-next">
-          <input type="text" id="category-input" value = "{{ current_category.title }}" autocomplete="off" placeholder="{{ config.strings.category_filter_placeholder }}" style="visibility: hidden;">
+          <input type="text" id="category-input" value = "{{ current_category.title }}" autocomplete="off" placeholder="{{ strings.category_filter_placeholder }}" style="visibility: hidden;">
           <input type="text" id="hidden-id-input" name="id" value="{{ next_snippet_id }}" hidden>
           <input type="text" id="hidden-category-input" name="cat" value="{{ current_category.id }}" hidden>
         </form>
         <noscript>
           <span id="js-disabled-category-warning">Sorry, filtering by category requires Javascript!</span>
         </noscript>
-        {% if not config.strings.instructions_details %}
-        <p id="beginners-link-text">{{ config.strings.beginners_hint }}</p>
+        {% if not strings.instructions_details %}
+        <p id="beginners-link-text">{{ strings.beginners_hint }}</p>
         {% endif %}
       </div>
       <div id="fixed-count-container" class="info" hidden></div>
@@ -74,8 +74,8 @@
     <link href="https://fonts.googleapis.com/css?family=Fondamento" rel="stylesheet" type="text/css">
     <link rel="prefetch" href="{{ config.lang_code }}?id={{ next_snippet_id }}&cat={{ current_category.id }}">
     <div id="footer" class="info">
-      <a target="_blank" id="github-link" href="https://github.com/eggpi/citationhunt">{{ config.strings.github_link_title }}</a>
-      <p>{{ config.strings.footer | format("https://wikitech.wikimedia.org/wiki/Portal:Tool_Labs", "https://translatewiki.net") if config.strings.footer else '' }}</p>
+      <a target="_blank" id="github-link" href="https://github.com/eggpi/citationhunt">{{ strings.github_link_title }}</a>
+      <p>{{ strings.footer | format("https://wikitech.wikimedia.org/wiki/Portal:Tool_Labs", "https://translatewiki.net") if strings.footer else '' }}</p>
     </div>
     <select id="lang-selector">
       {% for lang_code, lang_name in config.lang_codes_to_lang_names.items() | sort %}


### PR DESCRIPTION
This adds two new lang codes (zh_hant and zh_hans), and also allows redirecting the user to the correct lang code or changing the language in the UI based on the user's Accept-Language header.