### PR TITLE
Add direct link to CitationHunt on translatewiki.net

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -135,7 +135,7 @@
         <div class="col-10">
           <div id="footer" class="info">
             <a id="github-link" href="https://github.com/eggpi/citationhunt">{{ strings.github_link_title }}</a>
-            <p>{{ strings.footer | format("https://wikitech.wikimedia.org/wiki/Portal:Tool_Labs", "https://translatewiki.net") if strings.footer else '' }}</p>
+            <p>{{ strings.footer | format("https://wikitech.wikimedia.org/wiki/Portal:Tool_Labs", "https://translatewiki.net/wiki/Translating:CitationHunt") if strings.footer else '' }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changed link to https://translatewiki.net/wiki/Translating:CitationHunt so that new translators are able to find it easier.