### PR TITLE
Update translatewiki.net link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ we'll need to configure the new language, and also have a look at [Setting up a 
 
 The first step to bringing Citation Hunt to a new language is to translate its
 interface. If you want to help with that, please head over to
-[Translate Wiki](https://translatewiki.net/w/i.php?title=Special:Translate&group=citationhunt).
+[Translate Wiki](https://translatewiki.net/wiki/Translating:CitationHunt).
 
 ### Code changes
 


### PR DESCRIPTION
I would prefer this page for new translators, as old one lead directly to translation UI (confusing for first-timers).