### PR TITLE
Actually take all snippets from a section.

### DIFF
--- a/snippet_parser/core.py
+++ b/snippet_parser/core.py
@@ -228,7 +228,7 @@ class SnippetParser(object):
                     if root.tag in _LIST_TAGS:
                         snippet_roots = self._html_list_to_snippets(root)
                     else:
-                        snippet_roots = [self._make_snippet_root(root)]
+                        snippet_roots.append(self._make_snippet_root(root))
             else:
                 # Throw away the actual template, we don't need it.
                 for marker in tree.cssselect('.' + CITATION_NEEDED_MARKER_CLASS):
@@ -271,7 +271,7 @@ class SnippetParser(object):
             sectitle = ''
             if i != 0:
                 # Re-parse the section title because fast_parse is
-                # configured to ignore style tags (see above and 
+                # configured to ignore style tags (see above and
                 # https://github.com/earwig/mwparserfromhell/issues/40),
                 # but we do want to remove them now with strip_code().
                 sectitle = mwparserfromhell.parse(

--- a/snippet_parser/core_test.py
+++ b/snippet_parser/core_test.py
@@ -146,5 +146,28 @@ class SnippetParserTest(unittest.TestCase):
             "== Section title ''with Wikicode'' == \n\nIrrelevant content{{cn}}")
         self.assertEqual(section, 'Section title with Wikicode')
 
+    def test_multiple_snippets_in_section(self):
+        _, [_, snippets] = self._do_extract(
+            '<p>This needs a reference{citation_needed_tmpl}</p>'
+            '<p>So does this{citation_needed_tmpl}</p>',
+            'This needs a reference{{cn}}\n\nSo does this{{cn}}')
+        self.assertEqual(sorted([
+            '<div class="%s"><p>This needs a reference%s</p></div>' % (
+                core.SNIPPET_WRAPPER_CLASS, _CN_HTML),
+            '<div class="%s"><p>So does this%s</p></div>' % (
+                core.SNIPPET_WRAPPER_CLASS, _CN_HTML),
+            ]), sorted(snippets))
+
+    def test_no_duplicate_snippet(self):
+        _, [_, snippets] = self._do_extract(
+            ('<p>This{citation_needed_tmpl} needs a '
+                'reference{citation_needed_tmpl}</p>'),
+            'This{{cn}} needs a reference{{cn}}')
+        self.assertEqual([
+            '<div class="%s"><p>This%s needs a reference%s</p></div>' % (
+                core.SNIPPET_WRAPPER_CLASS, _CN_HTML, _CN_HTML),
+            ], snippets)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously we would accidentally drop all but the last snippet within a section.

This issue was found by @aikochou.