### PR TITLE
Updated scrollbars

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -96,7 +96,8 @@ html[dir="rtl"] #quotation {
 
 .ch-snippet {
     padding: 5px;
-    overflow-y: scroll;
+    overflow-y: auto;
+    overflow-x: hidden;
     max-height: inherit;
 }
 
@@ -380,4 +381,26 @@ body[theme=dark] #hamburguer-menu {
 
 body[theme=dark] #hamburguer-menu .menu-item {
     color: #6D9FF0;
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+::-webkit-scrollbar-track {
+  border: 1px solid dimgray;
+  transition: border 0.5s ease;
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: gray;
+  transition: background 0.5s ease;
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: dimgray;
 }


### PR DESCRIPTION
This should be the last minor fix I want to push.

The snippet's scrollbar should **only** appear when needed. Otherwise, it looks cluttered and confuses users when they see a scrollbar for an element without scrolling.
Example where the scrollbar doesn't appear:
<img width="1919" height="992" alt="Screenshot 2026-02-16 173831" src="https://github.com/user-attachments/assets/945ee135-813e-4ae2-9ce3-b498ef0be1ff" />

I've also updated the style of the scrollbar to make the tool seem more polished (this is more of a personal preference; feel free to discard the custom scrollbar as needed; colors can also be updated to better fit light/dark mode).
Example with the new scrollbar:
<img width="1020" height="993" alt="Screenshot 2026-02-16 173902" src="https://github.com/user-attachments/assets/f794724e-f92d-443d-9b25-10d1da3c3b66" />